### PR TITLE
Reduced manual entries, removed reconiciliation on cust. name, worked-around WTU issues

### DIFF
--- a/Amazon_B2C_Reconciler_App.py
+++ b/Amazon_B2C_Reconciler_App.py
@@ -16,7 +16,8 @@ try :
 except :
     print('File path not correct format')
 
-input_recon_country = input('Which country is being reconciled? (US, CA, DE, IT, ES, FR, UK, NL): ')
+input_recon_country = recon_path.split('\\')[-1]
+# input_recon_country = input('Which country is being reconciled? (US, CA, DE, IT, ES, FR, UK, NL): ')
 
 def region_recon(input_recon_country) :
     global recon_country
@@ -39,7 +40,7 @@ def region_recon(input_recon_country) :
 
 region_recon(input_recon_country)
 
-input_missing_orderids = input('Reconcile based on customer name due to missing order-ids in payment file? (y/n): ')
+# input_missing_orderids = input('Reconcile based on customer name due to missing order-ids in payment file? (y/n): ')
 
 print('Reconciliation region:',recon_region)
 

--- a/Amazon_Data_Cleansing.py
+++ b/Amazon_Data_Cleansing.py
@@ -109,7 +109,7 @@ principals_missing_internalids = amazon_statement_with_cust_name[(amazon_stateme
 principals_missing_internalids = principals_missing_internalids[['order-id','amount-description','amount','posted-date','Name','Internal ID']]
 
 if len(principals_missing_internalids) > 0 :
-    print(r'"/!\ WARNING:',len(principals_missing_internalids),r'orders with principals missing internal IDs that will result in',principals_missing_internalids['amount'].agg(lambda x : pd.to_numeric(x,errors='coerce')).sum(),r'Currency (without fees) Sum Check Levy /!\"')
+    print(r'"/!\ WARNING:',len(principals_missing_internalids),r'orders with principals missing internal IDs that will result in',principals_missing_internalids['amount'].agg(lambda x : pd.to_numeric(x,errors='coerce')).sum(),r' (without fees) Sum Check Levy /!\"')
     print('  !  LIST OF EXAMPLES: ',set(principals_missing_internalids['order-id']))
     print('  !  1) Check if order-ids exist in Netsuite\n  !  2) Check if Orders Report is in the date range of the statements\n  !  3) Check if there is an issue merging cust_internal_ids, or if there is an issue with the file\n')
     principals_missing_internalids.to_csv(recon_path_data+r'\principals_missing_internalids.csv')
@@ -181,10 +181,10 @@ amount_description_types = {'Commission':(525,'640101 - Amazon Fees'),
     'MarketplaceFacilitatorTax-Shipping':(599,'840203 - Other Levies'),
     'MarketplaceFacilitatorTax-RestockingFee':(599,'840203 - Other Levies'),
     'MarketplaceFacilitatorTax-Other':(599,'840203 - Other Levies'),
-    'MarketplaceFacilitatorTax-Principal':(599,'840203 - Other Levies'),
     'MarketplaceFacilitatorVAT-Principal':(742,'137002 - Un-reconciled B2C Payments '),# added whitespace so that je2_amount can still be determined
-    'MarketplaceFacilitatorVAT-Shipping':(742,'137002 - Un-reconciled B2C Payments ')# added whitespace so that je2_amount can still be determined
-    }
+    'MarketplaceFacilitatorVAT-Shipping':(742,'137002 - Un-reconciled B2C Payments '),
+    'FBA Pick & Pack Fee':(525,'640101 - Amazon Fees')# added whitespace so that je2_amount can still be determined
+    }#'MarketplaceFacilitatorTax-Principal':(599,'840203 - Other Levies'),
 
 print('Summary of data tables:')
 print('netsuite_product_data:',len(netsuite_product_data),'rows.')

--- a/Amazon_Order_Payment_Recon_EMEA_CA.py
+++ b/Amazon_Order_Payment_Recon_EMEA_CA.py
@@ -65,22 +65,22 @@ for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,
 
 # second iteration here to match refunds that are missing order-ids (didn't work in the loop above so had to separate)
 # ensure the red_deltas are actual and not because the refunds have 'Amazon' in the memo instead of the order-id
-if input_missing_orderids == 'y' :
-    for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,desc='Reconciling payments/refunds using Customer Name') :
-        cust_name = key[0]
-        cus_id = key[1]
-        order_id = key[3]
-        principal = val.loc['Principal']
-        grand_total = val.loc['Grand Total']
-        sale = val.loc['Sale']
-        credit = val.loc['Credit']
-        delta = val.loc['Delta']
-        if delta < 0 and abs(delta) == sale and grand_total == 0 :#1
-            amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#(bool(re.search('^[0-9-]*$',str(netsuite_payments.index)) == False))
-        if delta < 0 and abs(delta) / 2 == grand_total :#2
-            amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#'Amazon' in netsuite_payments.index
-        amazon_netsuite_recon_summary['Delta'].loc[key] = amazon_netsuite_recon_summary['Grand Total'].loc[key] - amazon_netsuite_recon_summary['Sale'].loc[key] - amazon_netsuite_recon_summary['Credit'].loc[key]
+# if input_missing_orderids == 'y' :
+#     for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,desc='Reconciling payments/refunds using Customer Name') :
+#         cust_name = key[0]
+#         cus_id = key[1]
+#         order_id = key[3]
+#         principal = val.loc['Principal']
+#         grand_total = val.loc['Grand Total']
+#         sale = val.loc['Sale']
+#         credit = val.loc['Credit']
+#         delta = val.loc['Delta']
+#         if delta < 0 and abs(delta) == sale and grand_total == 0 :#1
+#             amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#(bool(re.search('^[0-9-]*$',str(netsuite_payments.index)) == False))
+#         if delta < 0 and abs(delta) / 2 == grand_total :#2
+#             amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#'Amazon' in netsuite_payments.index
+#         amazon_netsuite_recon_summary['Delta'].loc[key] = amazon_netsuite_recon_summary['Grand Total'].loc[key] - amazon_netsuite_recon_summary['Sale'].loc[key] - amazon_netsuite_recon_summary['Credit'].loc[key]
+#
+# amazon_netsuite_recon_summary = amazon_netsuite_recon_summary#.astype(float)
 
-amazon_netsuite_recon_summary = amazon_netsuite_recon_summary#.astype(float)
-
-amazon_netsuite_recon_summary.to_csv(recon_path_data+r'\amazon_netsuite_recon_summary.csv')
+# amazon_netsuite_recon_summary.to_csv(recon_path_data+r'\amazon_netsuite_recon_summary.csv')

--- a/Amazon_Order_Payment_Recon_US.py
+++ b/Amazon_Order_Payment_Recon_US.py
@@ -80,18 +80,18 @@ for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,
 
 # second iteration here to match refunds that are missing order-ids (didn't work in the loop above so had to separate)
 # ensure the red_deltas are actual and not because the refunds have 'Amazon' in the memo instead of the order-id
-if input_missing_orderids == 'y' :
-    for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,desc='Reconciling payments/refunds using Customer Name') :
-        cust_name = key[0]
-        cus_id = key[1]
-        order_id = key[3]
-        principal = val.loc['Principal']
-        grand_total = val.loc['Grand Total']
-        sale = val.loc['Sale']
-        credit = val.loc['Credit']
-        delta = val.loc['Delta']
-        if delta < 0 and abs(delta) == sale and grand_total == 0 :#1
-            amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#(bool(re.search('^[0-9-]*$',str(netsuite_payments.index)) == False))
-        if delta < 0 and abs(delta) / 2 == grand_total :#2
-            amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#'Amazon' in netsuite_payments.index
-        amazon_netsuite_recon_summary['Delta'].loc[key] = amazon_netsuite_recon_summary['Grand Total'].loc[key] - amazon_netsuite_recon_summary['Sale'].loc[key] - amazon_netsuite_recon_summary['Credit'].loc[key] - amazon_netsuite_recon_summary['MarketplaceFacilitatorTax-Principal'].loc[key] - amazon_netsuite_recon_summary['MF Tax'].loc[key]
+# if input_missing_orderids == 'y' :
+#     for key,val in tqdm(amazon_netsuite_recon_summary.iterrows(),total=recon_length,desc='Reconciling payments/refunds using Customer Name') :
+#         cust_name = key[0]
+#         cus_id = key[1]
+#         order_id = key[3]
+#         principal = val.loc['Principal']
+#         grand_total = val.loc['Grand Total']
+#         sale = val.loc['Sale']
+#         credit = val.loc['Credit']
+#         delta = val.loc['Delta']
+#         if delta < 0 and abs(delta) == sale and grand_total == 0 :#1
+#             amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#(bool(re.search('^[0-9-]*$',str(netsuite_payments.index)) == False))
+#         if delta < 0 and abs(delta) / 2 == grand_total :#2
+#             amazon_netsuite_recon_summary['Credit'].loc[key] = netsuite_payments.loc[(netsuite_payments['ID'] == cus_id) & (netsuite_payments['Type'] == 'Customer Refund') & ('Amazon' in netsuite_payments.index)]['Amount (Foreign Currency)'].astype(float).sum()#'Amazon' in netsuite_payments.index
+#         amazon_netsuite_recon_summary['Delta'].loc[key] = amazon_netsuite_recon_summary['Grand Total'].loc[key] - amazon_netsuite_recon_summary['Sale'].loc[key] - amazon_netsuite_recon_summary['Credit'].loc[key] - amazon_netsuite_recon_summary['MarketplaceFacilitatorTax-Principal'].loc[key] - amazon_netsuite_recon_summary['MF Tax'].loc[key]

--- a/Amazon_Output_Sum_Check.py
+++ b/Amazon_Output_Sum_Check.py
@@ -24,8 +24,8 @@ if len(red_deltas_df) != 0 :
                 red_deltas_df['Comments'].loc[key] = 'Missing Payment'
             elif abs(val['Delta']) < abs(val['Grand Total']) :
                 red_deltas_df['Comments'].loc[key] = 'Base Price Delta'
-            elif input_missing_orderids == 'y' and (val['Sale'] != 0) and (abs(val['Credit']) > val['Sale']) :
-                red_deltas_df['Comments'].loc[key] = 'Refunds summed up incorrectly due to missing order-ids (match via cus_id)'
+            # elif input_missing_orderids == 'y' and (val['Sale'] != 0) and (abs(val['Credit']) > val['Sale']) :
+            #     red_deltas_df['Comments'].loc[key] = 'Refunds summed up incorrectly due to missing order-ids (match via cus_id)'
             elif (val['Credit'] != 0) and (val['Sale'] > abs(val['Credit'])) :
                 red_deltas_df['Comments'].loc[key] = 'Refund less than total amount'
             elif abs(val['Delta']) / 2 == abs(val['Grand Total']) or val['Grand Total'] == 0 or ( val['Grand Total'] < 0 and val['Credit'] == 0 ) :
@@ -44,10 +44,14 @@ if len(so_missing_rma) > 0 :
 
     netsuite_orders_rma = netsuite_orders_rma[netsuite_orders_rma['order-id'].isin(so_missing_rma)]
     netsuite_orders_rma = netsuite_orders_rma.iloc[:,[0,3,4,7]]
-    netsuite_orders_rma = netsuite_orders_rma[netsuite_orders_rma['Item'].str.startswith('PRD')].sort_values('Internal ID')
-    netsuite_orders_rma['No. of Line Items'] = netsuite_orders_rma.groupby(['Internal ID'])['Item'].transform('count')
 
-    print(netsuite_orders_rma)
+    try :
+        netsuite_orders_rma = netsuite_orders_rma[netsuite_orders_rma['Item'].str.startswith('PRD')].sort_values('Internal ID')
+        netsuite_orders_rma['No. of Line Items'] = netsuite_orders_rma.groupby(['Internal ID'])['Item'].transform('count')
+        print(netsuite_orders_rma)
+    except Exception as e :
+        print('netsuite_orders_rma: No Items starting with PRD in the column:',e)
+
 
     rmas_pending_receipt = []
     for key,val in netsuite_orders_rma.iterrows() :
@@ -63,7 +67,8 @@ if len(so_missing_rma) > 0 :
                 netsuite_orders_rma = netsuite_orders_rma.drop(key)
 else :
     print(r'"/!\ len(so_missing_rma) == 0 "')
-
+# except :
+#     print('so_missing_rma not generated')
 
 #### Recon Summary ####
 os.chdir(recon_path+r'\Output Files')


### PR DESCRIPTION
Reduced the number of manual entries required to initiate.
Removed Reconiciliation based on customer names.
Introduced try/except for  netsuite_orders_rma list generation, which was causing trouble for WTU recons.
Made Marketplace Facilitator Tax non-readible in Data Cleansing, as recon was double-counting tax in WTU.